### PR TITLE
fix(index.html): removing base tag

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -1,7 +1,6 @@
 <!doctype html>
 <html ng-app="ngDevstack" ng-controller="AppCtrl">
 <head>
-    <base href="/">
     <meta charset="UTF-8">
     <title ng-bind="pageTitle"></title>
 


### PR DESCRIPTION
If you have you project in other places then root or launch it "manually" like using URL "localhost/angular/ng-devstack" due to fixed "base" tag assets path are messed up.

TODO - please check if it will not break scenarios you use it for.
