### PR TITLE
feat(modules) Create modularized structure of ng-devstack

### DIFF
--- a/config.json
+++ b/config.json
@@ -5,6 +5,7 @@
 
     "paths" : {
         "scripts": [
+          "src/+(app|common)/**/*.module.js",
           "src/+(app|common)/**/*.js",
           "!src/+(app|common)/**/*.spec.js"
         ],

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -151,7 +151,7 @@ gulp.task('assets', ['assets:img', 'vendor:assets'], function () {
 var fnInject = function (path) {
     var inject = {
         css : (config.vendor_files.css).concat(config.build + '/assets/*.css'),
-        js  : (config.vendor_files.js).concat(config.build + '/+(app|common)/**/*.js')
+        js  : (config.vendor_files.js).concat(config.build + '/+(app|common)/**/*.module.js').concat(config.build + '/+(app|common)/**/*.js')
     };
 
     return gulp.src(inject.css.concat(inject.js), { read: false })
@@ -189,6 +189,7 @@ gulp.task('html', ['html:replace'], function () {
 // ============
 var testFiles = [
     config.build + '/vendor/**/*.js',
+    config.build + '/+(app|common)/**/*.module.js',
     config.build + '/+(app|common)/**/*.js',
     config.mocks,
     config.paths.tests

--- a/src/app/about/about.config.js
+++ b/src/app/about/about.config.js
@@ -1,8 +1,6 @@
 'use strict';
 
-angular.module('ngDevstack.about', [
-    'ui.router'
-])
+angular.module('ngDevstack.about')
 
 .config(function ($stateProvider) {
     $stateProvider.state('about', {
@@ -19,5 +17,4 @@ angular.module('ngDevstack.about', [
     });
 })
 
-.controller('AboutCtrl', function ($scope) {
-});
+;

--- a/src/app/about/about.controller.js
+++ b/src/app/about/about.controller.js
@@ -1,0 +1,8 @@
+'use strict';
+
+angular.module('ngDevstack.about')
+
+.controller('AboutCtrl', function ($scope) {
+})
+
+;

--- a/src/app/about/about.module.js
+++ b/src/app/about/about.module.js
@@ -1,0 +1,5 @@
+'use strict';
+
+angular.module('ngDevstack.about', [
+    'ui.router'
+]);

--- a/src/app/app.config.js
+++ b/src/app/app.config.js
@@ -1,13 +1,6 @@
 'use strict';
 
-angular.module('ngDevstack', [
-    'ngDevstack.templates',
-    'ngDevstack.conf',
-    'ngDevstack.home',
-    'ngDevstack.about',
-    'ui.bootstrap',
-    'ui.router'
-])
+angular.module('ngDevstack')
 
 .config(function ($urlRouterProvider) {
 
@@ -42,14 +35,4 @@ angular.module('ngDevstack', [
     });
 })
 
-.controller('AppCtrl', function ($rootScope, $scope) {
-
-    // handling UI Bootstrap Collapse plugin
-    $scope.isCollapsed = true;
-
-    $rootScope.$on('$stateChangeSuccess', function (event, toState, toParams, fromState, fromParams) {
-        if (angular.isDefined(toState.data.pageTitle)) {
-            $scope.pageTitle = toState.data.pageTitle + ' | ng-devstack';
-        }
-    });
-});
+;

--- a/src/app/app.controller.js
+++ b/src/app/app.controller.js
@@ -1,0 +1,17 @@
+'use strict';
+
+angular.module('ngDevstack')
+
+.controller('AppCtrl', function ($rootScope, $scope) {
+
+    // handling UI Bootstrap Collapse plugin
+    $scope.isCollapsed = true;
+
+    $rootScope.$on('$stateChangeSuccess', function (event, toState, toParams, fromState, fromParams) {
+        if (angular.isDefined(toState.data.pageTitle)) {
+            $scope.pageTitle = toState.data.pageTitle + ' | ng-devstack';
+        }
+    });
+})
+
+;

--- a/src/app/app.module.js
+++ b/src/app/app.module.js
@@ -1,0 +1,10 @@
+'use strict';
+
+angular.module('ngDevstack', [
+    'ngDevstack.templates',
+    'ngDevstack.conf',
+    'ngDevstack.home',
+    'ngDevstack.about',
+    'ui.bootstrap',
+    'ui.router'
+]);

--- a/src/app/home/home.config.js
+++ b/src/app/home/home.config.js
@@ -1,8 +1,6 @@
 'use strict';
 
-angular.module('ngDevstack.home', [
-    'ui.router'
-])
+angular.module('ngDevstack.home')
 
 .config(function ($stateProvider) {
     $stateProvider.state('home', {
@@ -19,5 +17,4 @@ angular.module('ngDevstack.home', [
     });
 })
 
-.controller('HomeCtrl', function ($scope) {
-});
+;

--- a/src/app/home/home.controller.js
+++ b/src/app/home/home.controller.js
@@ -1,0 +1,8 @@
+'use strict';
+
+angular.module('ngDevstack.home')
+
+.controller('HomeCtrl', function ($scope) {
+})
+
+;

--- a/src/app/home/home.module.js
+++ b/src/app/home/home.module.js
@@ -1,0 +1,5 @@
+'use strict';
+
+angular.module('ngDevstack.home', [
+    'ui.router'
+]);


### PR DESCRIPTION
feat(modules) Create modularized structure of ng-devstack:
- structure much more suited for bigger apps (each module separated into separate files)
- fixed Gulp and Karma config to reflect *.module.js file importance (it must be loaded first)

The good part is that change do not change old way - you can still do it as previous (with one file) but if you would like to separate module files - you can.
